### PR TITLE
Change how we install some packages due to version conflicts

### DIFF
--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -18,14 +18,13 @@ jenkins_java_args: ""
 jobs: '*'
 jobs_disabled: false
 
-dist_tools:
+dist_tools_unpinned:
   - acl
   - bzip2
   - curl
   - fonts-liberation
   - git
   - gnupg2
-  - google-chrome-stable=94.0.4606.71-1
   - jq
   - libffi-dev
   - libpq-dev
@@ -44,6 +43,9 @@ dist_tools:
   - xvfb
   - zip
   - zlib1g-dev
+
+dist_tools_pinned:
+  - google-chrome-stable=94.0.4606.71-1
 
 dm_applications:
   - api

--- a/playbooks/roles/jenkins/tasks/05_tools.yml
+++ b/playbooks/roles/jenkins/tasks/05_tools.yml
@@ -40,7 +40,7 @@
   apt:
     update_cache: yes
     state: present
-    name: "{{ dist_tools }}"
+    name: "{{ dist_tools_unpinned + dist_tools_pinned }}"
   notify:
     - restart jenkins
 

--- a/playbooks/roles/jenkins/tasks/99_upgrade_packages.yml
+++ b/playbooks/roles/jenkins/tasks/99_upgrade_packages.yml
@@ -2,4 +2,4 @@
 # Upgrades packages separately from the main Jenkins build playbook
 - name: Upgrade system packages to the latest LTS version
   tags: [apt]
-  apt: update_cache=yes name={{ dist_tools }} state=latest
+  apt: update_cache=yes name={{ dist_tools_unpinned }} state=latest


### PR DESCRIPTION
When trying to [spring clean Jenkins](https://trello.com/c/VQAfWQuS/2346-do-a-jenkins-spring-clean) we found an issue due to the chrome version being pinned.

This is because of how ansible works. When `update_cache` is run with `state=latest` it will automatically fail if any of the the tools it needs to install/update are pinned to a version. Therefore, we split the `dist_tools` list into two with most tools being in `dist_tools_unpinned` and the chrome tool locked in `dist_tools_pinned`.

When installing the tools initially we can combine the list, then later when using `update_cache` with `state=latest` we only need to pass the unpinned tools (`dist_tools_unpinned`).

This fixed the issue we were having where we couldn't fully update Jenkins.