### PR TITLE
Add link to Ansible changelog

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+# See https://github.com/ansible-community/ansible-build-data for changelog
 ansible==5.1.0


### PR DESCRIPTION
It's not obvious and trips us up every time because Dependabot doesn't know about it.