### PR TITLE
Remove handling of 3->4 ansible upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,8 @@ ${VIRTUALENV_ROOT}/activate:
 	[ -z $$VIRTUAL_ENV ] && [ ! -d venv ] && python3 -m venv venv || true
 
 .PHONY: requirements
-requirements: venv ## Install requirements; TODO: remove uninstall once everyone's on Ansible 4
+requirements: venv ## Install requirements
 	${VIRTUALENV_ROOT}/bin/pip install --upgrade pip
-	${VIRTUALENV_ROOT}/bin/pip show ansible | grep -q "Version: 4" || ${VIRTUALENV_ROOT}/bin/pip uninstall --yes ansible ansible-base ansible-core
 	${VIRTUALENV_ROOT}/bin/pip install -Ur requirements.txt
 	${VIRTUALENV_ROOT}/bin/ansible-galaxy install -r playbooks/requirements.yml
 


### PR DESCRIPTION
Everyone's now on Ansible 5, so we can remove the upgrade logic (from https://github.com/Crown-Commercial-Service/digitalmarketplace-jenkins/pull/432). Will speed up `make requirements` very slightly.