### PR TITLE
Add initial experimental support for https://dmp-so-ci.marketplace.team/

### DIFF
--- a/deploy-jenkins.sh
+++ b/deploy-jenkins.sh
@@ -32,6 +32,10 @@ if [ ! -z ${LOCALHOST+x} ]
 then 
   PLAYBOOK="playbooks/jenkins_playbook_local.yml"; 
   EXTRA_VARS+=(--connection "local")
+elif [ ! -z ${DMP_SO_CI_DANGEROUS_AND_EXPERIMENTAL_DO_NOT_USE+x} ]
+then
+  PLAYBOOK="playbooks/jenkins_playbook_dmp_so.yml"
+  EXTRA_VARS+=(--inventory "playbooks/hosts")
 else
   PLAYBOOK="playbooks/jenkins_playbook.yml"
   EXTRA_VARS+=(--inventory "playbooks/hosts")

--- a/playbooks/hosts
+++ b/playbooks/hosts
@@ -6,3 +6,10 @@ ci.marketplace.team ansible_user=ubuntu jenkins_data_device=/dev/disk/by-id/nvme
 [jenkins:vars]
 ansible_python_interpreter=/usr/bin/python3
 ec2_region=eu-west-1
+
+[jenkins_dmp_so]
+dmp-so-ci.marketplace.team ansible_user=ubuntu jenkins_data_device=/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_vol0a0785262cce46c9f
+
+[jenkins_dmp_so:vars]
+ansible_python_interpreter=/usr/bin/python3
+ec2_region=eu-west-2

--- a/playbooks/jenkins_playbook_dmp_so.yml
+++ b/playbooks/jenkins_playbook_dmp_so.yml
@@ -1,0 +1,17 @@
+---
+- hosts: jenkins_dmp_so
+  name: Setup Jenkins CI, config and dependencies
+  remote_user: ubuntu
+  become: yes
+  roles:
+    - jenkins
+    - role: willshersystems.sshd
+      tags: [sshd, jenkins]
+  vars:
+    sshd:
+      ClientAliveCountMax: 80
+      ClientAliveInterval: 45
+      LogLevel: VERBOSE
+      PasswordAuthentication: no
+      PermitRootLogin: no
+      X11Forwarding: no


### PR DESCRIPTION
Apply To Supply (DMP 1.5) has its own Jenkins - https://dmp-so-ci.marketplace.team/.

It's different in some ways (the jobs are significantly different) to the original Jenkins. However, it's very similar in others. I'd like to be able to use Ansible to manage the 1.5 Jenkins - particularly around managing the VM itself (e.g. keys, apt, Jenkins version).

Make a start on this by adding the new Jenkins to the hosts file and adding a new playbook that points to this host.

**Warning: this is experimental. Do not use without consulting with @bjgill.** Some parts just won't work (e.g. keys), whilst some parts will actively damage the 1.5 Jenkins configuration (e.g. jobs)