### PR TITLE
Use the system Ruby for tests instead of rbenv

### DIFF
--- a/job_definitions/functional_tests.yml
+++ b/job_definitions/functional_tests.yml
@@ -73,8 +73,6 @@
           template: "#${BUILD_NUMBER} - ${FT_BRANCH_NAME}"
           macro: true
       - shell: |
-          source /home/jenkins/.profile
-          rbenv install -s
           gem install bundler --conservative
 
           set +x # do not echo credentials - remove for debugging

--- a/job_definitions/smoke_smoulder_tests.yml
+++ b/job_definitions/smoke_smoulder_tests.yml
@@ -73,15 +73,10 @@
         try {
           stage('Prepare') {
             git url: 'git@github.com:alphagov/digitalmarketplace-functional-tests.git', branch: '${FT_BRANCH_NAME}', credentialsId: 'github_com_and_enterprise'
-            sh('''
-              source /home/jenkins/.profile
-              rbenv install -s
-              gem install bundler --conservative
-            ''')
+            sh('gem install bundler --conservative')
           }
           stage('{{ test_type.stage_name }}') {
             sh('''
-              source /home/jenkins/.profile
               set +x # do not echo credentials - remove for debugging
 
               export DM_API_DOMAIN="{{ app_urls[environment].data_api }}"


### PR DESCRIPTION
https://trello.com/c/ak9kYrlP/2450-vulnerability-fix-tracking

Since we upgraded to Jenkins 2.332.1, rbenv hasn't worked correctly. I'm not sure why, but Jenkins moved from SysV to systemd. As far as I can tell, the shells Jenkins creates for builds no longer source ~/.profile, which is needed for rbenv to work.

I don't think there's a better alternative. I can't work out how to get the tests working successfully in Docker - at least not in parallel mode. I recently added [a bodge](https://github.com/Crown-Commercial-Service/digitalmarketplace-jenkins/pull/480) to source ~/.profile at the start of each job that needed it. This mostly worked, and allowed tests to resume. However, we're still getting failures, and I'm not sure why.

So I think the least worst option is to abandon the use of rbenv on Jenkins in favour of the system version (2.7.0p, at the moment). I think that's fine because we can still use rbenv locally where it matters most, and nothing else on Jenkins is using Ruby.

Related PR: https://github.com/Crown-Commercial-Service/digitalmarketplace-functional-tests/pull/923