### PR TITLE
Stop asking to deploy to production

### DIFF
--- a/job_definitions/release_pipeline.yml
+++ b/job_definitions/release_pipeline.yml
@@ -281,9 +281,6 @@
 
       {% if application in dm_db_applications %}
       stage('DB migration on production') {
-        milestone()
-        input(message: "Release to production?")
-        milestone()
         throttle(['AppPipelines']) {
           node {
             build job: "database-migration-paas", parameters: [
@@ -297,11 +294,6 @@
       {% endif %}
 
       stage('Release to production') {
-        {% if application not in dm_db_applications %}
-        milestone()
-        input(message: "Release to production?")
-        milestone()
-        {% endif %}
         throttle(['AppPipelines']) {
           node {
             build job: "release-app-paas", parameters: [


### PR DESCRIPTION
The reason why we ask a human before deploying to production is "high risk changes or changes you could not manually test on preview you may also want to do manual testing on staging" (https://crown-commercial-service.github.io/digitalmarketplace-manual/developing-the-digital-marketplace/development-and-deployment-process.html#deploy-to-staging). However, since the Digital Marketplace is nearing the end of its life, this is no longer a significant issue. There are no plans for any further major changes. We haven't had any such changes recently.

So I propose removing the requirement for a human to approve before deploying to production. This will mean that the app will be automatically deployed if all the tests in staging pass. A human will still have needed to manually approve the deployment to staging.

My hope is that by halving the number of interactions a human needs to make to deploy, we'll save time and make it easier to keep the deployed versions of our dependencies up to date.