### PR TITLE
Stop using the extended choice plugin

### DIFF
--- a/job_definitions/database_backup.yml
+++ b/job_definitions/database_backup.yml
@@ -8,11 +8,12 @@
     triggers:
       - timed: "0 3 * * *"
     parameters:
-      - extended-choice:
+      - choice:
           name: STAGE
-          type: radio
-          default-value: production
-          value: preview,staging,production
+          choices:
+            - production
+            - staging
+            - preview
     dsl: |
 
       def notify_slack(icon, status) {

--- a/job_definitions/update_index_alias.yml
+++ b/job_definitions/update_index_alias.yml
@@ -23,11 +23,11 @@
           description: >
             The name of the index the alias will point to to, e.g.
             'g-cloud-9-2018-01-26'.
-      - extended-choice:
+      - choice:
           name: DELETE_OLD_INDEX
-          type: radio
-          default: no
-          value: yes,no
+          choices:
+            - "no"
+            - "yes"
           description: >
             If there is an index with the alias '<alias>-old' and
             this option is enabled then that index will be deleted.


### PR DESCRIPTION
It's had multiple open vulnerabilities for a few weeks now, and no sign of changes (https://plugins.jenkins.io/extended-choice-parameter/, https://issues.jenkins.io/browse/JENKINS-68096). We only use it minimally, and it's easy to replace. A dropdown isn't quite as nice as radio, but it's not much worse.

For the choices parameter, the value on the first line is the default.

Once this has been deployed, we can uninstall the plugin.