### PR TITLE
Remove the extended choice plugin

### DIFF
--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -72,7 +72,6 @@ jenkins_plugins:
   - build-user-vars-plugin
   - conditional-buildstep
   - cvs
-  - extended-choice-parameter
   - git
   - github
   - github-oauth


### PR DESCRIPTION
We stopped using it in https://github.com/Crown-Commercial-Service/digitalmarketplace-jenkins/pull/487. The replacement seems to have worked fine, so we can now remove the plugin (and its associated vulnerabilities).