### PR TITLE
Clean the data for preview monthly

### DIFF
--- a/job_definitions/clean_and_apply_db_dump.yml
+++ b/job_definitions/clean_and_apply_db_dump.yml
@@ -9,7 +9,13 @@
     concurrent: false
 {% if environment == 'staging' %}
     triggers:
+      {# Every Sunday at 4:00am #}
       - timed: "0 4 * * 0"
+{% endif %}
+{% if environment == 'preview' %}
+    triggers:
+      {# 1st of each month at 4:00am #}
+      - timed: "0 4 1 * *"
 {% endif %}
     dsl: |
 


### PR DESCRIPTION
We have a limitation in search-api that causes the tests to fail if there are more than ~330 pages of open/closed briefs: https://ci.marketplace.team/job/apps-are-up-preview/381418/smoke_20test_20report/

This is not a problem in production, where we only have 164 pages. However, it is a problem in the non-production environments, where we have tests creating briefs and leaving them open or closed.

It takes ~4 months to hit the issue after applying the clean database dump. So staging, which gets the data reapplied weekly, is not affected.

However, Preview only gets clean data when a human manually applies it. So every few months Preview's tests will start failing due to this issue. Fixing this issue would be difficult because it's due to a fundamental limitation in Opensearch.

So start automatically applying the clean database dump to Preview once a month. We're doing little development against the Digital Marketplace, so this should not be too disruptive. And it should prevent us suffering this issue with search-api in future.