### PR TITLE
Fix AWS token rotation

### DIFF
--- a/job_definitions/rotate_api_tokens.yml
+++ b/job_definitions/rotate_api_tokens.yml
@@ -96,7 +96,7 @@
               notify_slack(':kaboom:', '{{ stage.name }} - FAILED')
               echo "Error caught"
               currentBuild.result = 'FAILURE'
-              return
+              throw e
             }
           }
         }

--- a/job_definitions/rotate_aws_token.yml
+++ b/job_definitions/rotate_aws_token.yml
@@ -75,7 +75,7 @@
             notify_slack(':kaboom:', 'create-new-aws-token - FAILED')
             echo "Error caught"
             currentBuild.result = 'FAILURE'
-            return
+            throw e
           }
         }
       }
@@ -144,7 +144,7 @@
             notify_slack(':kaboom:', 'deactivate-old-aws-token - FAILED')
             echo "Error caught"
             currentBuild.result = 'FAILURE'
-            return
+            throw e
           }
         }
       }

--- a/job_definitions/rotate_aws_token.yml
+++ b/job_definitions/rotate_aws_token.yml
@@ -67,7 +67,7 @@
       stage("Add new token") {
         node {
           try {
-            sh('docker run --rm -e GITHUB_ACCESS_TOKEN digitalmarketplace/scripts scripts/rotate-api-tokens.sh create-new-aws-token "${STAGE}"')
+            sh('docker run --rm --env GITHUB_ACCESS_TOKEN --volume /home/jenkins/.aws/config:/root/.aws/config digitalmarketplace/scripts scripts/rotate-api-tokens.sh create-new-aws-token "${STAGE}"')
 
             notify_slack(':spinner:', 'create-new-aws-token - SUCCESS')
 
@@ -136,7 +136,7 @@
       stage("Deactivate old token") {
         node {
           try {
-            sh('docker run --rm -e GITHUB_ACCESS_TOKEN digitalmarketplace/scripts scripts/rotate-api-tokens.sh deactivate-old-aws-token "${STAGE}"')
+            sh('docker run --rm --env GITHUB_ACCESS_TOKEN --volume /home/jenkins/.aws/config:/root/.aws/config digitalmarketplace/scripts scripts/rotate-api-tokens.sh deactivate-old-aws-token "${STAGE}"')
 
             notify_slack(':spinner:', 'deactivate-old-aws-token - SUCCESS')
 

--- a/job_definitions/rotate_callback_token.yml
+++ b/job_definitions/rotate_callback_token.yml
@@ -76,7 +76,7 @@
               notify_slack(':kaboom:', '{{ job_stage.name }} - FAILED')
               echo "Error caught"
               currentBuild.result = 'FAILURE'
-              return
+              throw e
             }
           }
         }


### PR DESCRIPTION
When rotating the AWS access token, we need access to the AWS CLI config file. This gives us access to the configuration for the development-infrastructure and production-infrastructure AWS profiles. All profiles use the Ec2InstanceMetadata credential source, so we aren't passing any secrets in.

Also fix a bug in error handling logic I noticed.

I manually applied the changes, and they fixed https://ci.marketplace.team/job/rotate-AWS-access-token/