### PR TITLE
Throttle database dump cleaning

### DIFF
--- a/job_definitions/clean_and_apply_db_dump.yml
+++ b/job_definitions/clean_and_apply_db_dump.yml
@@ -7,6 +7,11 @@
     project-type: pipeline
     description: "Takes the latest production database dump, cleans it, and applies it to target stage. Also S3."
     concurrent: false
+    properties:
+      - throttle:
+          categories:
+            - clean-database-dump
+          option: category
 {% if environment == 'staging' %}
     triggers:
       {# Every Sunday at 4:00am #}

--- a/playbooks/roles/jenkins/templates/jenkins/hudson.plugins.throttleconcurrents.ThrottleJobProperty.xml.j2
+++ b/playbooks/roles/jenkins/templates/jenkins/hudson.plugins.throttleconcurrents.ThrottleJobProperty.xml.j2
@@ -22,6 +22,11 @@
       <categoryName>AppPipelines</categoryName>
       <nodeLabeledPairs/>
     </hudson.plugins.throttleconcurrents.ThrottleJobProperty_-ThrottleCategory>
+    <hudson.plugins.throttleconcurrents.ThrottleJobProperty_-ThrottleCategory>
+      <maxConcurrentTotal>1</maxConcurrentTotal>
+      <categoryName>clean-database-dump</categoryName>
+      <nodeLabeledPairs/>
+    </hudson.plugins.throttleconcurrents.ThrottleJobProperty_-ThrottleCategory>
   </categories>
   <throttledPipelinesByCategory class="tree-map"/>
 </hudson.plugins.throttleconcurrents.ThrottleJobProperty_-DescriptorImpl>


### PR DESCRIPTION
As part of cleaning the database dump, we create a local database with a fixed port. The fixed port means that we can only run one instance of this job at a time.

Uses the same throttle config as EndToEndTest-{environment}.

Should prevent a recurrence of https://ci.marketplace.team/job/clean-and-apply-db-dump-staging/287/