### PR TITLE
Use available version of google-chrome-stable

### DIFF
--- a/playbooks/roles/jenkins/defaults/main.yml
+++ b/playbooks/roles/jenkins/defaults/main.yml
@@ -47,7 +47,7 @@ dist_tools_unpinned:
   - zlib1g-dev
 
 dist_tools_pinned:
-  - google-chrome-stable=101.0.4951.41-1
+  - google-chrome-stable=101.0.4951.54-1
 
 dm_applications:
   - api


### PR DESCRIPTION
The previous version is no longer available for download. Fortunately, chromedriver 101.0.4951.41 is compatible with Chrome 101.0.4951.*

I've already manually applied this to Jenkins to fix the broken tests: https://ci.marketplace.team/job/apps-are-up-staging/