### PR TITLE
Run job to create approved service edit report monthly

### DIFF
--- a/job_definitions/export_approved_service_edits_to_s3.yml
+++ b/job_definitions/export_approved_service_edits_to_s3.yml
@@ -1,0 +1,23 @@
+- job:
+    name: "export-approved-service-edits-production"
+    display-name: "Export approved service edits - production"
+    project-type: freestyle
+    description: "Runs the export-approved-service-edits.py script, which uploads the generated CSV file to the reports S3 bucket"
+    triggers:
+      {# 2nd of each month at 3:00am #}
+      - timed: "0 3 2 * *"
+    publishers:
+      - trigger-parameterized-builds:
+          - project: notify-slack
+            condition: UNSTABLE_OR_WORSE
+            predefined-parameters: |
+              USERNAME=export-approved-service-edits
+              JOB='Export approved service edits - production'
+              ICON=:fire:
+              STAGE=production
+              STATUS=FAILED
+              URL=<${BUILD_URL}consoleFull|#${BUILD_NUMBER}>
+              CHANNEL='#dm-2ndline'
+    builders:
+      - shell: |
+          docker run --rm -e NOTIFY_API_TOKEN -e DM_DATA_API_TOKEN_PRODUCTION --user $(id -u) digitalmarketplace/scripts scripts/export-approved-service-edits.py --stage production "$(date --date='-1 month' +%Y-%m)" "$(date +%Y-%m)"


### PR DESCRIPTION
https://trello.com/c/F0h3RRkV/2494-send-ccs-list-of-approved-service-edits-for-month-past

A category admin wants a monthly report of approved service edits. We've been triggering this manually, but this is getting a bit tedious. Add a Jenkins job to create the report, upload it to S3, and send a notification email.

I've tested this against preview, and it seems to work fine: https://ci.marketplace.team/job/Test/7/console

Follows on from https://github.com/Crown-Commercial-Service/digitalmarketplace-scripts/pull/794