### PR TITLE
Update Jenkins and Java version

### DIFF
--- a/playbooks/roles/jenkins/tasks/05_jenkins.yml
+++ b/playbooks/roles/jenkins/tasks/05_jenkins.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Add Jenkins apt repository key.
-  apt_key: url="https://pkg.jenkins.io/debian-stable/jenkins.io.key" state=present
+  apt_key: url="https://pkg.jenkins.io/debian-stable/jenkins.io-2023.key" state=present
 
 - name: Add Jenkins apt repository.
   apt_repository: repo="deb https://pkg.jenkins.io/debian-stable binary/"  state=present update_cache=yes

--- a/playbooks/roles/jenkins/tasks/05_tools.yml
+++ b/playbooks/roles/jenkins/tasks/05_tools.yml
@@ -1,6 +1,6 @@
 ---
-- name: Install OpenJDK JRE 8
-  apt: name=openjdk-8-jre state=latest update_cache=yes
+- name: Install OpenJDK JRE 17
+  apt: name=openjdk-17-jre state=latest update_cache=yes
   notify:
     - restart jenkins
 

--- a/playbooks/roles/jenkins/templates/jenkins_defaults.j2
+++ b/playbooks/roles/jenkins/templates/jenkins_defaults.j2
@@ -8,7 +8,7 @@ JAVA=/usr/bin/java
 
 JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
 # arguments to pass to java
-JAVA_ARGS="-Djava.awt.headless=true -Dfile.encoding=UTF8 -Xmx4096m -XX:MaxPermSize=1024m"  # Allow graphs etc. to work even when an X server is present
+JAVA_ARGS="-Djava.awt.headless=true -Dfile.encoding=UTF8 -Xmx4096m -XX:MaxMetaspaceSize=1024m"  # Allow graphs etc. to work even when an X server is present
 
 # Allow JS and CSS on HTML Publisher pages
 JAVA_ARGS="${JAVA_ARGS} -Dhudson.model.DirectoryBrowserSupport.CSP=\"sandbox allow-same-origin allow-scripts; default-src 'self' 'unsafe-inline' 'unsafe-eval' data:;\""
@@ -59,10 +59,9 @@ PREFIX=/jenkins
 # --javahome=$JAVA_HOME
 # --httpPort=$HTTP_PORT (default 8080; disable with -1)
 # --httpsPort=$HTTP_PORT
-# --ajp13Port=$AJP_PORT
 # --argumentsRealm.passwd.$ADMIN_USER=[password]
 # --argumentsRealm.roles.$ADMIN_USER=admin
 # --webroot=~/.jenkins/war
 # --prefix=$PREFIX
 
-JENKINS_ARGS="--webroot=/var/cache/jenkins/war --httpPort=$HTTP_PORT --ajp13Port=$AJP_PORT $JENKINS_ACCESSLOG"
+JENKINS_ARGS="--webroot=/var/cache/jenkins/war --httpPort=$HTTP_PORT $JENKINS_ACCESSLOG"


### PR DESCRIPTION
Remove `ajp13Port` argument as it is not compatible with the latest version of Jenkins.
Make updates to allow us to use the latest version of Jenkins and a newer version of Java